### PR TITLE
Deploy as a Docker Cloud Stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.4
+MAINTAINER Kevin Cantwell <kevin.cantwell@gmail.com>
+
+RUN apk -v --update add \
+  bash \
+  ca-certificates \
+  python \
+  py-pip \
+  groff \
+  less \
+  mailcap \
+  && \
+  pip install --upgrade awscli s3cmd python-magic && \
+  apk -v --purge del py-pip && \
+  rm /var/cache/apk/*
+
+ADD . /docker-cloud-startup
+WORKDIR /docker-cloud-startup
+CMD ./cfn-create-stack.sh

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ At [Vidsy](http://vidsy.co) and [Timehop](https://timehop.com) we wanted to use 
 - Adds Docker Cloud UUID as a tag on the AWS instance.
 - Retrieves EC2 instance tags.
 - Adds certain tags as a Docker Cloud node label.
-- Redeploys stacks.
 - Delete all installed packages and Bash history.
 
 ### Supported Linux Distros

--- a/README.md
+++ b/README.md
@@ -1,72 +1,85 @@
-<h1 align="center">Docker Cloud Startup</h1>
-
-<p align="center">Automatically register a new EC2 instance as a <a href="https://cloud.docker.com">Docker Cloud</a> node on launch with tags.</p>
+# Docker Cloud Startup
 
 ### What
 
-> This script was developed before **Docker Cloud** launched. It works on both platforms.
+This repo provides a Docker Cloud stack that spawns ["Bring Your Own Host"](https://docs.docker.com/docker-cloud/infrastructure/byoh/) nodes as EC2 instances in an AWS autoscaling group. Each EC2 instance registers itself as a Docker Cloud node with sensible default EC2 tags and Docker Cloud labels.
 
-This script is run at startup on new EC2 instances (using [`user-data`](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html)) to register the instance as a [Docker Cloud](https://cloud.docker.co) node (using the ["bring you own node"](https://docs.docker.com/docker-cloud/feature-reference/byoh) feature).
+[![Deploy to Docker Cloud](https://files.cloud.docker.com/images/deploy-to-dockercloud.svg)](https://cloud.docker.com/stack/deploy/)
 
-### Usage
+The "Deploy to Cloud" button above can be used to get up and running. You will need to configure it with the following details:
+
+1. Your Docker Cloud username.
+1. A Docker Cloud API key (Managed under account [settings](https://cloud.docker.com/_/account)).
+1. AWS region to deploy nodes into.
+1. AWS credentials with privileges to create CloudFormation stacks.
+1. AWS availability zones to launch EC2 instances into.
+1. An AWS IAM role to launch EC2 instances with.
+1. An AWS security group(s) to launch EC2 instances with which exposes 6783/tcp, 6783/udp, and 2375/tcp.
+1. An AWS ssh keypair to launch EC2 instances with.
+1. An AWS vpc subnet(s) to launch EC2 instances into.
+1. A AWS S3 bucket to host the startup script.
+1. A unique name for the AWS CloudFormation stack.
+1. Any tags you may wish to launch EC2 instances with.
+
+**Note:** Currently the service _must_ be configured with VPC subnets, IAM role, security group, and ssh keypair.
+
+When deployed, this stack will upload `script.sh` with _public-read_ permissions to `s3://$S3_BUCKET/docker-cloud-startup/$CLOUDFORMATION_STACK_NAME/script.sh`. Next it creates a CloudFormation stack from `cloud-formation-template.json`, passing in various parameters sourced from the environment.
+
+When an EC2 instance launches, a user data shell script fetches and executes the script at `s3://$S3_BUCKET/docker-cloud-startup/$CLOUDFORMATION_STACK_NAME/script.sh`. This script is responsible for registering the EC2 instance as a BYOH node and setting tags and labels. 
+
+### EC2 Tags and BYOH Node Labels
+
+Aside from the EC2 tags you specify in the stack definition, a `Docker-Cloud-UUID` tag will always be set. Every BYOH node will also be labeled with the following instance details: `availabilityZone`, `instanceId`, `privateIp`, and `region`.
+
+Use the `$TAGS` env var to specify custom EC2 tags. Any tags that begin with "Docker-Cloud-" are automatically applied as labels to the corresponding BYOH node.
+
+### Execute Not as a Docker Cloud Service
 
 ```bash
-# Download URI for script
-SCRIPT_URI="https://raw.githubusercontent.com/vidsy/docker-cloud-startup/master/script.sh"
-
-# Docker Cloud User ID
-USER="batman"
-
-# Docker Cloud API Key
-API_KEY="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-
-# Timeout for node deployment (e.g. 30s, 2m, 10m)
-TIMEOUT="1m"
-
-# Stack UUID (needed for redeploy)
-STACK_UUID="xxx"
-
-curl -s $SCRIPT_URI | bash -s $USER $API_KEY $TIMEOUT $STACK_UUID
+docker run --rm -it \
+  -e DOCKER_USER=<your_docker_username> \
+  -e API_KEY=<your_docker_cloud_api_key> \
+  -e AWS_REGION=<aws_region> \
+  -e AWS_ACCESS_KEY_ID=*********************** \
+  -e AWS_SECRET_ACCESS_KEY==*********************** \
+  -e AVAILABILITY_ZONES=<comma_separated_availability_zones> \
+  -e IAM_ROLE=<iam_role_name> \
+  -e SECURITY_GROUPS=<comma_separated_security_group_ids> \
+  -e KEYPAIR_NAME=<aws_keypair_name> \
+  -e SUBNETS=<comma_separated_subnet_ids> \
+  -e S3_BUCKET=<writeable_s3_bucket> \
+  -e CLOUDFORMATION_STACK_NAME=<unique_name> \
+  -e DEPLOYMENT_TIMEOUT=2m \
+  -e AMI_ID=ami-2d39803a \
+  -e INSTANCE_TYPE=t2.micro \
+  -e DESIRED_CAPACITY=1 \
+  -e TAGS="Key=Foo,Value=Bar Key=Biz,Value=Baz" \
+  timehop/docker-cloud-startup:latest
 ```
 
-### What's it do?
+### Why
 
+At [Vidsy](http://vidsy.co) and [Timehop](https://timehop.com) we wanted to use Docker Cloud, but also benefit from the controls and features of AWS.
+
+## Details
+
+### cfn-create-stack.sh
+
+- Executed by the Docker Cloud service.
+- Creates a CloudFormation stack with autoscaling resources.
+
+### script.sh
+
+- Executed on EC2 during launch.
 - Installs `docker-cloud-cli` and `aws-cli`.
 - Sets environment variables for Docker Cloud authentication.
 - Uses "Bring Your Own Node" CLI command to register new instance as Docker Cloud node.
 - Waits for Docker Cloud node deployment to finish.
 - Adds Docker Cloud UUID as a tag on the AWS instance.
 - Retrieves EC2 instance tags.
-- Adds each tag as a Docker Cloud node tag.
-- Redeploys the stack.
+- Adds certain tags as a Docker Cloud node label.
+- Redeploys stacks.
 - Delete all installed packages and Bash history.
-
-### Why
-
-At [Vidsy](http://vidsy.co) we wanted to use Docker Cloud, but also benefit from the controls and features of AWS.
-
-### Tutum?
-
-The script was created back before [Docker Cloud](https://cloud.docker.co) existed, and the platform was called [Tutum](https://tutum.co). If you are still using Tutum then please refer to [this release](https://github.com/vidsy/docker-cloud-startup/releases/tag/v1.0.0-tutum).
-
-### Credentials from S3
-
-Make sure `aws-cli` is installed and a IAM role ([example](https://gist.github.com/revett/491cac41972722a80fca)) configured:
-
-```bash
-# Set AWS Region
-AWS_DEFAULT_REGION=$(curl -fs ${METADATA_SERVICE_URL}/placement/availability-zone | sed 's/.$//')
-
-# Set S3 Bucket
-S3_BUCKET="my-private-bucket"
-
-# Set Environment
-ENVIRONMENT="staging"
-
-# Fetch from S3
-USER=$(aws s3 cp s3://${S3_BUCKET}/${ENVIRONMENT}/tutum_auth_user - --region ${AWS_DEFAULT_REGION})
-API_KEY=$(aws s3 cp s3://${S3_BUCKET}/${ENVIRONMENT}/tutum_auth_api_key - --region ${AWS_DEFAULT_REGION})
-```
 
 ### Supported Linux Distros
 
@@ -91,3 +104,4 @@ Look at any [open issues](https://github.com/vidsy/tutum-startup/issues?utf8=%E2
 - [@revett](https://github.com/revett)
 - [@jskeates](https://github.com/jskeates)
 - [@stevenjack](https://github.com/stevenjack)
+- [@kevin-cantwell](https://github.com/kevin-cantwell)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,57 @@ A `Docker-Cloud-UUID` tag will always be set on every ec2 instance if launched s
 
 Use the `TAGS` configuration to specify custom EC2 tags. Any tags that begin with "Docker-Cloud-" are automatically applied as labels to the Docker Cloud node.
 
+### AWS Credentials
+
+The AWS credentials you configure the service with will need to have s3 write access to the bucket you configure, as well as access for creating CloudFormation stacks. Here is a sample policy you may use. Replace `${S3_BUCKET}` with the configured bucket name:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cloudformation:*",
+        "iam:CreateRole",
+        "iam:PutRolePolicy",
+        "iam:PassRole",
+        "iam:CreateInstanceProfile",
+        "iam:AddRoleToInstanceProfile",
+        "ec2:CreateSecurityGroup",
+        "autoscaling:CreateLaunchConfiguration",
+        "autoscaling:CreateAutoScalingGroup"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Deny",
+      "Action": [
+        "cloudformation:UpdateStack",
+        "cloudformation:DeleteStack"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": ["arn:aws:s3:::${S3_BUCKET}"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:DeleteObject"
+      ],
+      "Resource": ["arn:aws:s3:::${S3_BUCKET}/*"]
+    }
+  ]
+}
+```
+
+_If you don't wish to allow the `iam:*` actions, then you must configure the service with a role name to use. Ditto for security groups._
+
 ### Create AWS Resources Manually
 
 You may also create the same autoscaling resources without deploying a Docker Cloud stack. Just execute the following.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ When an EC2 instance launches, a user data shell script fetches and executes the
 
 ### EC2 Tags and BYOH Node Labels
 
-A `Docker-Cloud-UUID` tag will always be set on every ec2 instance if launched successfully. Every BYOH node will also be labeled with the following instance details: `availabilityZone`, `instanceId`, `instanceType`, `privateIp`, and `region`.
+A `Docker-Cloud-UUID` and `Docker-Cloud-Namespace` tag will always be set on every ec2 instance if launched successfully. Every BYOH node will also be labeled with the following instance details: `availabilityZone`, `instanceId`, `instanceType`, `privateIp`, and `region`.
 
 Use the `TAGS` configuration to specify custom EC2 tags. Any tags that begin with "Docker-Cloud-" are automatically applied as labels to the Docker Cloud node.
 

--- a/cfn-create-stack.sh
+++ b/cfn-create-stack.sh
@@ -70,7 +70,7 @@ _output "Creating Cloudformation stack..."
 # to character length restrictions of parameter fields.
 read -d '' USER_DATA << EOF || true
 #!/bin/bash
-curl -s https://s3.amazonaws.com/$script_path | bash -s "${DOCKERCLOUD_AUTH}" ${DOCKERCLOUD_NAMESPACE} ${DEPLOYMENT_TIMEOUT}
+curl -s https://s3.amazonaws.com/$script_path | bash -s "${DOCKERCLOUD_AUTH}" ${DOCKERCLOUD_NAMESPACE} ${DEPLOYMENT_TIMEOUT} ${REDEPLOY_STACKS}
 EOF
 
 aws --region ${AWS_REGION} cloudformation create-stack \

--- a/cfn-create-stack.sh
+++ b/cfn-create-stack.sh
@@ -52,6 +52,7 @@ INSTANCE_TYPE=${INSTANCE_TYPE:-m3.medium}
 DESIRED_CAPACITY=${DESIRED_CAPACITY:-1}
 DEPLOYMENT_TIMEOUT=${DEPLOYMENT_TIMEOUT:-2m}
 DOCKERCLOUD_AUTH="Basic $(echo -n "$DOCKER_USER:$API_KEY" | base64)"
+DOCKERCLOUD_NAMESPACE=${DOCKERCLOUD_NAMESPACE:-${DOCKER_USER}}
 
 _output "Uploading startup script..."
 
@@ -69,7 +70,7 @@ _output "Creating Cloudformation stack..."
 # to character length restrictions of parameter fields.
 read -d '' USER_DATA << EOF || true
 #!/bin/bash
-curl -s https://s3.amazonaws.com/$script_path | bash -s "${DOCKERCLOUD_AUTH}" ${DEPLOYMENT_TIMEOUT}
+curl -s https://s3.amazonaws.com/$script_path | bash -s "${DOCKERCLOUD_AUTH}" ${DOCKERCLOUD_NAMESPACE} ${DEPLOYMENT_TIMEOUT}
 EOF
 
 aws --region ${AWS_REGION} cloudformation create-stack \

--- a/cfn-create-stack.sh
+++ b/cfn-create-stack.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# --
+# Usage:
+#
+# ./cfn-create-stack.sh
+# --
+
+# --
+# Stop script if any command fails and run _cleanup() function
+# --
+
+set -e
+trap _cleanup ERR
+
+# --
+# Functions
+# --
+
+function _cleanup {
+  printf "[docker-cloud-startup] ERROR - STOPPING EARLY.\n"
+}
+
+function _error {
+  printf "[docker-cloud-startup]   -> Error: $1.\n"
+}
+
+function _finished {
+  printf "[docker-cloud-startup] SCRIPT COMPLETE.\n"
+}
+
+function _ok {
+  printf "[docker-cloud-startup]   -> ok.\n"
+}
+
+function _output {
+  printf "[docker-cloud-startup] $1\n"
+}
+
+function _result {
+  printf "[docker-cloud-startup]   -> $1\n"
+}
+
+_output "Uploading user-data script..."
+
+script_path="$S3_BUCKET/docker-cloud-startup/$CLOUDFORMATION_STACK_NAME/script.sh"
+aws s3 cp --acl public-read script.sh "s3://$script_path"
+
+DOCKERCLOUD_AUTH="Basic $(echo -n "$DOCKER_USER:$API_KEY" | base64)"
+# We are forced to outsource the major portion of user data to an external location due to character length restrictions
+read -d '' user_data << EOF || true
+#!/bin/bash
+curl -s https://s3.amazonaws.com/$script_path | bash -s "$DOCKERCLOUD_AUTH" ${DEPLOYMENT_TIMEOUT:-2m}
+EOF
+
+_result "user-data: \"https://s3.amazonaws.com/$script_path\""
+
+_ok
+
+
+_output "Creating Cloudformation stack..."
+
+# Requires: $AWS_REGION, $AWS_ACCESS_KEY_ID, $AWS_SECRET_ACCESS_KEY,
+# $CLOUDFORMATION_STACK_NAME, $KEYPAIR_NAME, $IAM_ROLE, $SECURITY_GROUPS, $AVAILABILITY_ZONES,
+# $SUBNETS, $user_data
+aws --region ${AWS_REGION} cloudformation create-stack \
+  --stack-name "$CLOUDFORMATION_STACK_NAME" \
+  --template-body file://cloud-formation-template.json \
+  --capabilities CAPABILITY_IAM \
+  --parameters ParameterKey=ImageId,ParameterValue=${AMI_ID:-ami-2d39803a} \
+               ParameterKey=KeyPairName,ParameterValue=${KEYPAIR_NAME} \
+               ParameterKey=IamInstanceProfile,ParameterValue=${IAM_ROLE} \
+               ParameterKey=SecurityGroups,ParameterValue=\"${SECURITY_GROUPS}\" \
+               ParameterKey=AvailabilityZones,ParameterValue=\"${AVAILABILITY_ZONES}\" \
+               ParameterKey=Subnets,ParameterValue=\"${SUBNETS}\" \
+               ParameterKey=InstanceType,ParameterValue=${INSTANCE_TYPE:-t2.micro} \
+               ParameterKey=DesiredCapacity,ParameterValue=${DESIRED_CAPACITY:-1} \
+               ParameterKey=UserData,ParameterValue="$(echo -n "$user_data" | base64)" \
+  --tags Key=Name,Value=${CLOUDFORMATION_STACK_NAME} ${TAGS}
+
+_ok
+
+_finished

--- a/cloud-formation-template.json
+++ b/cloud-formation-template.json
@@ -1,7 +1,5 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Metadata": {
-  },
   "Parameters": {
     "ImageId": {
       "Type": "String",
@@ -10,70 +8,129 @@
     },
     "InstanceType": {
       "Type": "String",
-      "Description": "EC2 instance type",
-      "Default": "t2.micro"
+      "Description": "EC2 instance type.",
+      "Default": "m3.medium"
     },
     "DesiredCapacity": {
       "Type": "Number",
-      "Description": "The initial desired scale",
+      "Description": "The initial desired scale.",
       "Default": 1
     },
     "KeyPairName": {
       "Type": "String",
-      "Description": "EC2 key pair name",
+      "Description": "EC2 keypair name (optional)."
     },
     "IamInstanceProfile": {
       "Type": "String",
-      "Description": "Launch configuration IAM Role"
+      "Description": "IAM instance profile name (optional)."
     },
     "SecurityGroups": {
       "Type": "CommaDelimitedList",
-      "Description": "Launch configuration security groups"
+      "Description": "Security groups (optional)."
     },
     "AvailabilityZones": {
       "Type": "CommaDelimitedList",
-      "Description": "Autoscaling group AZs"
+      "Description": "Autoscaling group AZs. Only specify if Subnets is empty."
+    },
+    "VpcId": {
+      "Type": "String",
+      "Description": "Security group VPC (optional). Only required if SecurityGroups is empty and Subnets is not empty."
     },
     "Subnets": {
       "Type": "CommaDelimitedList",
-      "Description": "Autoscaling group VPC subnets"
+      "Description": "Autoscaling group VPC subnets. Only specify if AvailabilityZones is empty."
     },
     "UserData": {
       "Type": "String",
       "Description": "User data script for cloud-init (base64-encoded)"
     }
   },
+  "Conditions": {
+    "HasNoKeyPair":           {"Fn::Equals": [{"Ref": "KeyPairName"}, ""]},
+    "HasNoIamRole":           {"Fn::Equals": [{"Ref": "IamInstanceProfile"}, ""]},
+    "HasNoVPCId":             {"Fn::Equals": [{"Ref": "VpcId"}, ""]},
+    "HasNoSecurityGroups":    {"Fn::Equals": [{"Fn::Join": [",", {"Ref": "SecurityGroups"}]}, ""]},
+    "HasNoSubnets":           {"Fn::Equals": [{"Fn::Join": [",", {"Ref": "Subnets"}]}, ""]},
+    "HasNoAvailabilityZones": {"Fn::Equals": [{"Fn::Join": [",", {"Ref": "AvailabilityZones"}]}, ""]}
+  },
   "Resources": {
-    "LaunchConfiguration": {
-      "Type": "AWS::AutoScaling::LaunchConfiguration",
+    "DockerCloudIamRole": {
+      "Condition": "HasNoIamRole",
+      "Type": "AWS::IAM::Role",
       "Properties": {
-        "AssociatePublicIpAddress": true,
-        "IamInstanceProfile": { "Ref": "IamInstanceProfile" },
-        "ImageId": { "Ref": "ImageId" },
-        "InstanceType": { "Ref": "InstanceType" },
-        "InstanceMonitoring": false,
-        "KeyName": { "Ref": "KeyPairName" },
-        "SecurityGroups": { "Ref": "SecurityGroups" },
-        "UserData": { "Ref": "UserData" }
-      },
-      "Metadata": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [{
+            "Effect": "Allow",
+            "Principal": {"Service": ["ec2.amazonaws.com"]},
+            "Action": ["sts:AssumeRole"]
+          }]
+        },
+        "Policies": [{
+          "PolicyName": "docker-cloud-byoh",
+          "PolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [{      
+              "Effect": "Allow",      
+              "Action": ["ec2:DescribeTags", "ec2:CreateTags"],
+              "Resource": "*"      
+            }]
+          }
+        }]
       }
     },
-    "AutoScalingGroup": {
+    "DockerCloudIamInstanceProfile": {
+      "Condition": "HasNoIamRole",
+      "Type": "AWS::IAM::InstanceProfile",
+      "Properties": {
+        "Path": "/",
+        "Roles": [{"Ref": "DockerCloudIamRole"}]
+      }
+    },
+    "DockerCloudSecurityGroup": {
+      "Condition": "HasNoSecurityGroups",
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Docker Cloud BYOH",
+        "VpcId": {"Fn::If": ["HasNoVPCId", {"Ref": "AWS::NoValue"}, {"Ref": "VpcId"}]},
+        "SecurityGroupEgress": {
+          "Fn::If": [
+            "HasNoVPCId",
+            {"Ref": "AWS::NoValue"},
+            [{"IpProtocol": "-1", "CidrIp": "0.0.0.0/0"}]
+          ]
+        },
+        "SecurityGroupIngress": [
+          {"IpProtocol": "tcp", "FromPort": 22,   "ToPort": 22,   "CidrIp": "0.0.0.0/0"},
+          {"IpProtocol": "udp", "FromPort": 6783, "ToPort": 6783, "CidrIp": "0.0.0.0/0"},
+          {"IpProtocol": "tcp", "FromPort": 6783, "ToPort": 6783, "CidrIp": "0.0.0.0/0"},
+          {"IpProtocol": "tcp", "FromPort": 2375, "ToPort": 2375, "CidrIp": "0.0.0.0/0"}
+        ]
+      }
+    },
+    "DockerCloudLaunchConfiguration": {
+      "Type": "AWS::AutoScaling::LaunchConfiguration",
+      "Properties": {
+        "ImageId": {"Ref": "ImageId"},
+        "InstanceType": {"Ref": "InstanceType"},
+        "AssociatePublicIpAddress": {"Fn::If": ["HasNoSubnets", {"Ref": "AWS::NoValue"}, true]},
+        "KeyName": {"Fn::If": ["HasNoKeyPair", {"Ref": "AWS::NoValue"}, {"Ref": "KeyPairName"}]},
+        "InstanceMonitoring": false,
+        "UserData": {"Ref": "UserData"},
+        "IamInstanceProfile": {"Fn::If": ["HasNoIamRole", {"Ref": "DockerCloudIamInstanceProfile"}, {"Ref": "IamInstanceProfile"}]},
+        "SecurityGroups": {"Fn::If": ["HasNoSecurityGroups", [{"Ref": "DockerCloudSecurityGroup"}], {"Ref": "SecurityGroups"}]}
+      }
+    },
+    "DockerCloudAutoScalingGroup": {
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "Properties": {
-        "AvailabilityZones": { "Ref": "AvailabilityZones" },
-        "DesiredCapacity": { "Ref": "DesiredCapacity" },
-        "LaunchConfigurationName": { "Ref": "LaunchConfiguration" },
+        "DesiredCapacity": {"Ref": "DesiredCapacity"},
+        "LaunchConfigurationName": {"Ref": "DockerCloudLaunchConfiguration"},
         "MaxSize": 100,
         "MinSize": 0,
-        "VPCZoneIdentifier": { "Ref": "Subnets" }
-      },
-      "Metadata": {
-      },
-      "DependsOn": [
-        "LaunchConfiguration"
-      ]
+        "VPCZoneIdentifier": {"Fn::If": ["HasNoSubnets", {"Ref": "AWS::NoValue"}, {"Ref": "Subnets"}]},
+        "AvailabilityZones": {"Fn::If": ["HasNoAvailabilityZones", {"Ref": "AWS::NoValue"}, {"Ref": "AvailabilityZones"}]}
+      }
     }
   }
 }

--- a/cloud-formation-template.json
+++ b/cloud-formation-template.json
@@ -40,9 +40,30 @@
       "Type": "CommaDelimitedList",
       "Description": "Autoscaling group VPC subnets. Only specify if AvailabilityZones is empty."
     },
-    "UserData": {
+    "DeployScriptLocation": {
       "Type": "String",
-      "Description": "User data script for cloud-init (base64-encoded)"
+      "Description": "Required for UserData script."
+    },
+    "DockerCloudUser": {
+      "Type": "String",
+      "Description": "Required for UserData script."
+    },
+    "DockerCloudApiKey": {
+      "Type": "String",
+      "Description": "Required for UserData script."
+    },
+    "DockerCloudNamespace": {
+      "Type": "String",
+      "Description": "Required for UserData script."
+    },
+    "DeploymentTimeout": {
+      "Type": "String",
+      "Description": "Required for UserData script.",
+      "Default": "2m"
+    },
+    "RedeployStacks": {
+      "Type": "String",
+      "Description": "Required for UserData script."
     }
   },
   "Conditions": {
@@ -116,7 +137,14 @@
         "AssociatePublicIpAddress": {"Fn::If": ["HasNoSubnets", {"Ref": "AWS::NoValue"}, true]},
         "KeyName": {"Fn::If": ["HasNoKeyPair", {"Ref": "AWS::NoValue"}, {"Ref": "KeyPairName"}]},
         "InstanceMonitoring": false,
-        "UserData": {"Ref": "UserData"},
+        "UserData"       : { "Fn::Base64" : { "Fn::Join" : ["", [
+          "#!/bin/bash\n",
+          "curl -s ", {"Ref": "DeployScriptLocation"}, " | bash -s", 
+          " \"Basic ", { "Fn::Base64" : { "Fn::Join" : [":", [{"Ref": "DockerCloudUser"}, {"Ref": "DockerCloudApiKey"}]]}}, "\"",
+          " ", {"Ref": "DockerCloudNamespace"},
+          " ", {"Ref": "DeploymentTimeout"},
+          " ", {"Ref": "RedeployStacks"}
+        ]]}},
         "IamInstanceProfile": {"Fn::If": ["HasNoIamRole", {"Ref": "DockerCloudIamInstanceProfile"}, {"Ref": "IamInstanceProfile"}]},
         "SecurityGroups": {"Fn::If": ["HasNoSecurityGroups", [{"Ref": "DockerCloudSecurityGroup"}], {"Ref": "SecurityGroups"}]}
       }

--- a/cloud-formation-template.json
+++ b/cloud-formation-template.json
@@ -67,7 +67,7 @@
           }]
         },
         "Policies": [{
-          "PolicyName": "docker-cloud-byoh",
+          "PolicyName": {"Ref": "AWS::StackName"},
           "PolicyDocument": {
             "Version": "2012-10-17",
             "Statement": [{      

--- a/cloud-formation-template.json
+++ b/cloud-formation-template.json
@@ -1,0 +1,79 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Metadata": {
+  },
+  "Parameters": {
+    "ImageId": {
+      "Type": "String",
+      "Description": "EC2 AMI ID (Supported distros: https://docs.docker.com/docker-cloud/infrastructure/byoh/)",
+      "Default": "ami-2d39803a"
+    },
+    "InstanceType": {
+      "Type": "String",
+      "Description": "EC2 instance type",
+      "Default": "t2.micro"
+    },
+    "DesiredCapacity": {
+      "Type": "Number",
+      "Description": "The initial desired scale",
+      "Default": 1
+    },
+    "KeyPairName": {
+      "Type": "String",
+      "Description": "EC2 key pair name",
+    },
+    "IamInstanceProfile": {
+      "Type": "String",
+      "Description": "Launch configuration IAM Role"
+    },
+    "SecurityGroups": {
+      "Type": "CommaDelimitedList",
+      "Description": "Launch configuration security groups"
+    },
+    "AvailabilityZones": {
+      "Type": "CommaDelimitedList",
+      "Description": "Autoscaling group AZs"
+    },
+    "Subnets": {
+      "Type": "CommaDelimitedList",
+      "Description": "Autoscaling group VPC subnets"
+    },
+    "UserData": {
+      "Type": "String",
+      "Description": "User data script for cloud-init (base64-encoded)"
+    }
+  },
+  "Resources": {
+    "LaunchConfiguration": {
+      "Type": "AWS::AutoScaling::LaunchConfiguration",
+      "Properties": {
+        "AssociatePublicIpAddress": true,
+        "IamInstanceProfile": { "Ref": "IamInstanceProfile" },
+        "ImageId": { "Ref": "ImageId" },
+        "InstanceType": { "Ref": "InstanceType" },
+        "InstanceMonitoring": false,
+        "KeyName": { "Ref": "KeyPairName" },
+        "SecurityGroups": { "Ref": "SecurityGroups" },
+        "UserData": { "Ref": "UserData" }
+      },
+      "Metadata": {
+      }
+    },
+    "AutoScalingGroup": {
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+      "Properties": {
+        "AvailabilityZones": { "Ref": "AvailabilityZones" },
+        "DesiredCapacity": { "Ref": "DesiredCapacity" },
+        "LaunchConfigurationName": { "Ref": "LaunchConfiguration" },
+        "MaxSize": 100,
+        "MinSize": 0,
+        "VPCZoneIdentifier": { "Ref": "Subnets" }
+      },
+      "Metadata": {
+      },
+      "DependsOn": [
+        "LaunchConfiguration"
+      ]
+    }
+  }
+}

--- a/docker-cloud.yml
+++ b/docker-cloud.yml
@@ -37,3 +37,5 @@ docker-cloud-startup:
     - TAGS=
     # Defaults to 2m if left unset. Use the following syntax: 1s, 1m, 1h, etc.
     - DEPLOYMENT_TIMEOUT=2m
+    # Optional. List of stack names to redeploy after a new node is added.
+    - REDEPLOY_STACKS=

--- a/docker-cloud.yml
+++ b/docker-cloud.yml
@@ -1,0 +1,27 @@
+docker-cloud-startup:
+  image: 'timehop/docker-cloud-startup:latest'
+  autodestroy: always
+  environment:
+    - DOCKER_USER=<your_docker_username>
+    - API_KEY=<your_docker_cloud_api_key>
+    - AWS_REGION=<aws_region>
+    # These aws keys must have create-stack privileges for Cloudformation
+    - AWS_ACCESS_KEY_ID=<*******>
+    - AWS_SECRET_ACCESS_KEY=<*******>
+    # How long cloud-init takes to wait for a BYOH node to deploy
+    - DEPLOYMENT_TIMEOUT=2m
+    # Defaulted to Ubuntu Server 14.04 LTS (HVM), SSD Volume Type - ami-2d39803a
+    - AMI_ID=ami-2d39803a
+    - INSTANCE_TYPE=t2.micro
+    - DESIRED_CAPACITY=1
+    - AVAILABILITY_ZONES=<comma_separated_aws_zones>
+    - CLOUDFORMATION_STACK_NAME=<desired_stack_name>
+    - IAM_ROLE=<custom_iam_role_name>
+    - KEYPAIR_NAME=<custom_keypair_name>
+    # This bucket is where script.sh is copied to and the user data script reads/executes it.
+    - S3_BUCKET=<write_accessible>
+    # Must have 6783/tcp, 6783/udp, and 2375/tcp open
+    - SECURITY_GROUPS=<custom_security_group>
+    - SUBNETS=<comma_separated_vpc_subnets>
+    # Optional EC2 tags to apply
+    - 'TAGS=Key=Foo,Value=Bar Key=Biz,Value=Baz'

--- a/docker-cloud.yml
+++ b/docker-cloud.yml
@@ -2,26 +2,36 @@ docker-cloud-startup:
   image: 'timehop/docker-cloud-startup:latest'
   autodestroy: always
   environment:
+    # Your Docker Cloud username and api key belonging to the account where nodes will be deployed.
     - DOCKER_USER=<your_docker_username>
     - API_KEY=<your_docker_cloud_api_key>
-    - AWS_REGION=<aws_region>
-    # These aws keys must have create-stack privileges for Cloudformation
+    # AWS credentials must have CloudFormation create-stack privs and s3 write privs to $S3_BUCKET
     - AWS_ACCESS_KEY_ID=<*******>
     - AWS_SECRET_ACCESS_KEY=<*******>
-    # How long cloud-init takes to wait for a BYOH node to deploy
-    - DEPLOYMENT_TIMEOUT=2m
-    # Defaulted to Ubuntu Server 14.04 LTS (HVM), SSD Volume Type - ami-2d39803a
-    - AMI_ID=ami-2d39803a
-    - INSTANCE_TYPE=t2.micro
-    - DESIRED_CAPACITY=1
-    - AVAILABILITY_ZONES=<comma_separated_aws_zones>
-    - CLOUDFORMATION_STACK_NAME=<desired_stack_name>
-    - IAM_ROLE=<custom_iam_role_name>
-    - KEYPAIR_NAME=<custom_keypair_name>
-    # This bucket is where script.sh is copied to and the user data script reads/executes it.
+    - AWS_REGION=us-east-1
+    # Writes to: s3://$S3_BUCKET/docker-cloud-startup/${CLOUDFORMATION_STACK_PREFIX}-${UUID}/script.sh.
     - S3_BUCKET=<write_accessible>
-    # Must have 6783/tcp, 6783/udp, and 2375/tcp open
-    - SECURITY_GROUPS=<custom_security_group>
-    - SUBNETS=<comma_separated_vpc_subnets>
-    # Optional EC2 tags to apply
-    - 'TAGS=Key=Foo,Value=Bar Key=Biz,Value=Baz'
+    # Actual stack name will be suffixed with a UUID
+    - CLOUDFORMATION_STACK_PREFIX=docker-cloud-byoh
+    # Defaults to Ubuntu Server 14.04 LTS (HVM), SSD Volume Type - ami-2d39803a, if left unset.
+    - AMI_ID=ami-2d39803a
+    # Defaults to m3.medium (smallest non-EC2 classic instance) if left unset.
+    - INSTANCE_TYPE=m3.medium
+    # Defaults to 1
+    - DESIRED_CAPACITY=1
+    # Defaults to expose 6783/tcp, 6783/udp, and 2375/tcp
+    - SECURITY_GROUPS=
+    # Conditional VPC id. If $SECURITY_GROUPS is empty and $SUBNETS is not empty, this must be specified.
+    - VPC_ID=
+    # Conditional subnets list. If $AVAILABILITY_ZONES is empty, this must be specified.
+    - SUBNETS=
+    # Conditional az list. If $SUBNETS is empty, this must be specified.
+    - AVAILABILITY_ZONES=us-east1b,us-east1c,us-east1d
+    # Defaaults to an IAM role with ec2 tagging capability.
+    - IAM_ROLE=
+    # Optional.
+    - KEYPAIR_NAME=
+    # Optional ec2 tags. Uses AWS syntax: 'Key=Foo,Value=Bar Key=Biz,Value=Baz'
+    - TAGS=
+    # Defaults to 2m if left unset. Use the following syntax: 1s, 1m, 1h, etc.
+    - DEPLOYMENT_TIMEOUT=2m

--- a/docker-cloud.yml
+++ b/docker-cloud.yml
@@ -5,6 +5,8 @@ docker-cloud-startup:
     # Your Docker Cloud username and api key belonging to the account where nodes will be deployed.
     - DOCKER_USER=<your_docker_username>
     - API_KEY=<your_docker_cloud_api_key>
+    # Conditional. Required only if deploying nodes to a Docker Cloud organization.
+    - DOCKERCLOUD_NAMESPACE=
     # AWS credentials must have CloudFormation create-stack privs and s3 write privs to $S3_BUCKET
     - AWS_ACCESS_KEY_ID=<*******>
     - AWS_SECRET_ACCESS_KEY=<*******>

--- a/script.sh
+++ b/script.sh
@@ -47,7 +47,7 @@ function _result {
 
 _output "Checking arguments..."
 
-if [ "$#" -ne 3 ]; then
+if [ "$#" -ne 4 ]; then
   _error "illegal number of parameters"
   exit 1
 else
@@ -176,6 +176,8 @@ _output "Setting input variables..."
 DEPLOYMENT_TIMEOUT=$3
 _result "DEPLOYMENT_TIMEOUT: \"$DEPLOYMENT_TIMEOUT\""
 
+REDEPLOY_STACKS=$4
+_result "REDEPLOY_STACKS: \"$REDEPLOY_STACKS\""
 _ok
 
 # --
@@ -265,6 +267,19 @@ _output "Add AWS tags..."
 aws ec2 create-tags --resources $INSTANCE_ID --tags Key=Docker-Cloud-UUID,Value=$NODE_UUID Key=Docker-Cloud-Namespace,Value=$DOCKERCLOUD_NAMESPACE
 
 _ok
+
+# --
+# Redeploy stacks
+# --
+
+if [ "$REDEPLOY_STACKS" != "" ]; then
+  _output "Redeploy stack..."
+
+  # Splits stack list on comma char
+  docker-cloud stack redeploy --sync $(echo -n $REDEPLOY_STACKS | sed  's/,/ /g')
+
+  _ok
+fi
 
 # --
 # Cleanup instance

--- a/script.sh
+++ b/script.sh
@@ -262,7 +262,7 @@ _ok
 
 _output "Add AWS tags..."
 
-aws ec2 create-tags --resources $INSTANCE_ID --tags Key="Docker-Cloud-UUID",Value=$NODE_UUID
+aws ec2 create-tags --resources $INSTANCE_ID --tags Key=Docker-Cloud-UUID,Value=$NODE_UUID Key=Docker-Cloud-Namespace,Value=$DOCKERCLOUD_NAMESPACE
 
 _ok
 

--- a/script.sh
+++ b/script.sh
@@ -47,7 +47,7 @@ function _result {
 
 _output "Checking arguments..."
 
-if [ "$#" -ne 2 ]; then
+if [ "$#" -ne 3 ]; then
   _error "illegal number of parameters"
   exit 1
 else
@@ -67,7 +67,8 @@ _output "Setting final variables..."
 METADATA_SERVICE_URI="http://169.254.169.254/latest/meta-data"
 _result "METADATA_SERVICE_URI: \"$METADATA_SERVICE_URI\""
 
-DOCKER_CLOUD_CLI_VERSION="1.0.1"
+# CLI versions prior to 1.0.5 do not have namespace support
+DOCKER_CLOUD_CLI_VERSION="1.0.7"
 _result "DOCKER_CLOUD_CLI_VERSION: \"$DOCKER_CLOUD_CLI_VERSION\""
 
 AWS_CLI_VERSION="1.9.20"
@@ -149,6 +150,9 @@ _output "Setting Docker Cloud environment variables..."
 export DOCKERCLOUD_AUTH=$1
 _result "DOCKERCLOUD_AUTH: \"Basic xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\""
 
+export DOCKERCLOUD_NAMESPACE=$2
+_result "DOCKERCLOUD_NAMESPACE: \"$DOCKERCLOUD_NAMESPACE\""
+
 _ok
 
 # --
@@ -169,7 +173,7 @@ _ok
 
 _output "Setting input variables..."
 
-DEPLOYMENT_TIMEOUT=$2
+DEPLOYMENT_TIMEOUT=$3
 _result "DEPLOYMENT_TIMEOUT: \"$DEPLOYMENT_TIMEOUT\""
 
 _ok
@@ -267,7 +271,7 @@ _ok
 # --
 
 _output "Cleanup instance..."
-unset AWS_DEFAULT_REGION DOCKERCLOUD_USER DOCKERCLOUD_APIKEY NODE_UUID
+unset AWS_DEFAULT_REGION DOCKERCLOUD_NAMESPACE NODE_UUID
 pip uninstall docker-cloud awscli -y
 case "$OS_KIND" in
   debian)


### PR DESCRIPTION
This PR includes changes to `script.sh` as well as introducing a push-button method for deploying byoh nodes into an AWS autoscaling group. 

The long and short of it:
- Adds a Dockerfile for creating a AWS LaunchConfiguration and AutoscalingGroup via CloudFormation. Each EC2 instance launched executes `script.sh` on startup.
- A versioned copy of `script.sh` is deployed to the user's s3 account. This prevents existing deployments from being affected by future changes.
- Adds a `docker-cloud.yml` file and  "Deploy to Cloud" button to the README
- The README has been rewritten to guide a newbie through deploying boyh nodes into autoscaling groups via Docker Cloud, thereby automating the deployment of autoscaling groups and launch configurations.
- Labels DC nodes with a `name=value` pattern. Also labels nodes with some default ec2 information, such as instanceType and region. EC2 tags that begin with "Docker-Cloud-" (case-sensitive) will become a node label like so: A ec2 Tag `Key=Docker-Cloud-Foo,Name=Bar` becomes DC label `Foo=Bar`.
- Controversially removes the stack redeployment step. It wasn't clear to me that an autoscaling group should be coupled to a single DC stack. Perhaps it can be optionally configured?

There's a few new files so it may not be super duper clear how they work together. The logical flow can be broken down like this:
1. A DC Stack is created based on `docker-cloud.yml`
2. When deployed, `script.sh` is copied to s3 and a CloudFormation stack is created from the template `cloud-formation-template.json`. CloudFormation parameters are sourced from the service env vars.
3. CloudFormation creates at least two resources: `AWS::AutoScaling::LaunchConfiguration` and `AWS::AutoScaling::AutoScalingGroup`; and potentially these as well: `AWS::EC2::SecurityGroup`, `AWS::IAM::InstanceProfile`, and `AWS::IAM::Role`
4. On launch, each EC2 instance executes user data to pull `script.sh` from s3 and run it.

Let me know what you think of all this. I know one of your goals was to migrate `script.sh` into a go app, and I considered doing that, but I quickly ran into a problem I don't know how to solve. The command: `docker-cloud node byo` doesn't seem to have a equivalent api call. There might be a workaround (perhaps the tokens don't expire?), but I didn't think about it very hard.
